### PR TITLE
Provided frame/quad size functionality

### DIFF
--- a/peachy.lua
+++ b/peachy.lua
@@ -209,9 +209,19 @@ function peachy:togglePlay()
   end
 end
 
---- Provides information about frame size
+--- Provides information about frame viewport
 function peachy:getViewport()
-  return self.frame.quad:getViewport()
+    return self.frame.quad:getViewport()
+end
+
+--- Provides width stored in the metadata of a current frame
+function peachy:getWidth()
+    return self._jsonData.frames[self.frameIndex].frame.w
+end
+
+--- Provides height stored in the metadata of a current frame
+function peachy:getHeight()
+    return self._jsonData.frames[self.frameIndex].frame.h
 end
 
 --- Internal: handles the ping-pong animation type.

--- a/peachy.lua
+++ b/peachy.lua
@@ -209,6 +209,11 @@ function peachy:togglePlay()
   end
 end
 
+--- Provides information about frame size
+function peachy:getViewport()
+  return self.frame.quad:getViewport()
+end
+
 --- Internal: handles the ping-pong animation type.
 --
 -- Should only be called when we actually want to bounce.


### PR DESCRIPTION
For collision detection I need width and height of a sprite I just loaded. Of course I can hardcode them and store in separate variables, but why should I do it if it is already in the metadata? Added some simple functions to get quad viewport and width/height of a frame.

Was thinking should I add some asserts, but all the checks are already done in init method, so I think it is already checked, why to bother again.

Please let me know if any changes required. Thanks for the awesome library!